### PR TITLE
Correct capitalization of included filename

### DIFF
--- a/bk2421.h
+++ b/bk2421.h
@@ -18,7 +18,7 @@
 #ifndef _BK2421
 #define _BK2421
 
-#include <arduino.h>
+#include <Arduino.h>
 #include "blocks.h"
 
 #define SET(x,y) (x |=(1<<y))					//-Bit set/clear macros


### PR DESCRIPTION
The correct spelling is Arduino.h, not arduino.h. This caused compilation to fail on filename case sensitive operating systems such as Linux.

Fixes https://github.com/dzlonline/HCDlib/issues/1